### PR TITLE
Strings are now written in UTF-8

### DIFF
--- a/flipflop.py
+++ b/flipflop.py
@@ -801,7 +801,7 @@ class WSGIServer(object):
 
         def write(data):
             if type(data) is str:
-                data = data.encode('latin-1')
+                data = data.encode('utf-8')
 
             assert type(data) is bytes, 'write() argument must be bytes'
             assert headers_set, 'write() before start_response()'


### PR DESCRIPTION
I had massive problems while trying to serve utf8 content. Fed up with encapsulating my strings in a bunch of encode-functions I decided to just hack your wsgi server to write Utf8 strings directly.

This is just a quick hack, I'm always happy about some feedback, e.g. if this was something very stupid I did.