### PR TITLE
Fix incorrect error message for non-byte HTTP status code

### DIFF
--- a/flipflop.py
+++ b/flipflop.py
@@ -845,7 +845,7 @@ class WSGIServer(object):
             if isinstance(status, str):
                 status = status.encode('latin-1')
 
-            assert type(status) is bytes, 'Status must be a string'
+            assert type(status) is bytes, 'Status must be bytes'
             assert len(status) >= 4, 'Status must be at least 4 characters'
             assert int(status[:3]), 'Status must begin with 3-digit code'
             assert status[3] == 0x20, 'Status must have a space after code'


### PR DESCRIPTION
When a HTTP status code is a str, it is converted to bytes.

An assertion checks that the value is in fact bytes.

If the status code is neither bytes, nor a str, this assertion
will be triggered.

However, the error message incorrectly says "Status must be
string" instead.

This simple commit corrects the error message.